### PR TITLE
setup/railsのデータベースをポスグレに設定

### DIFF
--- a/spe-con/Gemfile
+++ b/spe-con/Gemfile
@@ -29,6 +29,7 @@ gem "kamal", require: false
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", require: false
 
+gem 'dotenv-rails'
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/spe-con/Gemfile.lock
+++ b/spe-con/Gemfile.lock
@@ -90,6 +90,9 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     dotenv (3.1.7)
+    dotenv-rails (3.1.7)
+      dotenv (= 3.1.7)
+      railties (>= 6.1)
     drb (2.2.1)
     ed25519 (1.3.0)
     erubi (1.13.1)
@@ -131,6 +134,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.8)
     minitest (5.25.4)
     msgpack (1.7.5)
     net-imap (0.5.5)
@@ -147,6 +151,9 @@ GEM
     net-smtp (0.5.0)
     net-ssh (7.3.0)
     nio4r (2.7.4)
+    nokogiri (1.18.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.2-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.2-aarch64-linux-musl)
@@ -295,6 +302,7 @@ PLATFORMS
   aarch64-linux-musl
   arm-linux-gnu
   arm-linux-musl
+  ruby
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl
@@ -303,6 +311,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   debug
+  dotenv-rails
   kamal
   pg (~> 1.1)
   puma (>= 5.0)

--- a/spe-con/config/database.yml
+++ b/spe-con/config/database.yml
@@ -18,10 +18,10 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  <% if ENV["DB_HOST"] %>
-  host: <%= ENV["DB_HOST"] %>
-  username: postgres
-  password: postgres
+  <% if ENV["DB"] %>
+  host: <%= ENV["DB"] %>
+  username: <%= ENV["USER"] %>
+  password: <%= ENV["PASSWORD"] %>
   <% end %>
 
 
@@ -87,8 +87,8 @@ production:
   primary: &primary_production
     <<: *default
     database: spe_con_production
-    username: spe_con
-    password: <%= ENV["SPE_CON_DATABASE_PASSWORD"] %>
+    username: <%= ENV["USER"] %>
+    password: <%= ENV["PASSWORD"] %>
   cache:
     <<: *primary_production
     database: spe_con_production_cache


### PR DESCRIPTION
## 目的
- railsがdockerで作成されたDB(ポスグレ)に接続できるように設定しました

## 何をやったか
- gemfileにgem 'dotenv-rails'を記述とインストール
- back/spe-con/配下に.envファイル作成
- config/database.ymlファイルに環境変数を適用

## 注意事項
- docker-composeをもとにコンテナを作成する際エラーが出力される可能性があります。理由環境変数には優先順位があるので。
ローカルの環境変数の次に.envファイルの環境変数を参照しにいくのでローカルと.envファイルで名前が同じ環境変数がある場合そちらが優先される。