### PR TITLE
fix/composeファイル名変更

### DIFF
--- a/spe-con/compose-pro.yaml
+++ b/spe-con/compose-pro.yaml
@@ -13,7 +13,7 @@ services:
   backend:
     build:
       context: ./back/spe-con
-      dockerfile: Dockerfile.pro
+      dockerfile: Dockerfile-pro
     volumes:
       - ./back/spe-con:/rails
     ports:


### PR DESCRIPTION
## 目的
- renderでrailsをデプロイさせるため
## やったこと
- composeファイルの名前を修正

## 注意事項
- 特にありません

