### PR TITLE
本番環境のcors制約のデバック

### DIFF
--- a/spe-con/config/environments/production.rb
+++ b/spe-con/config/environments/production.rb
@@ -27,6 +27,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
   config.hosts << "back-fznr.onrender.com"
+  config.hosts << "spe-con.com"
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 


### PR DESCRIPTION
## 目的
 - 本番環境のcors制約でフロントからのリクエストがブロックされる問題の解消

## やったこと
- productions.rbにフロントのurlを追加


## 注意事項
- 特にありません